### PR TITLE
fixes: stolon_hash does not pass cargo clippy --all --tests #2

### DIFF
--- a/stolon_hash/src/lib.rs
+++ b/stolon_hash/src/lib.rs
@@ -32,12 +32,12 @@ mod tests {
         hasher.update("frog");
         let hashed = hasher.finalize();
         assert_eq!(
-            crack::<Sha256>(&["dog", "cat", "bat"].join("\n").as_bytes(), &hashed),
+            crack::<Sha256>(["dog", "cat", "bat"].join("\n").as_bytes(), &hashed),
             None
         );
 
         assert_eq!(
-            crack::<Sha512>(&["dog", "frog", "bat"].join("\n").as_bytes(), &hashed),
+            crack::<Sha512>(["dog", "frog", "bat"].join("\n").as_bytes(), &hashed),
             None
         )
     }
@@ -48,7 +48,7 @@ mod tests {
         hasher.update("frog");
         let hashed = hasher.finalize();
         assert_eq!(
-            crack::<Sha256>(&["dog", "frog", "bat"].join("\n").as_bytes(), &hashed),
+            crack::<Sha256>(["dog", "frog", "bat"].join("\n").as_bytes(), &hashed),
             Some("frog".as_bytes())
         );
     }
@@ -59,7 +59,7 @@ mod tests {
         hasher.update("frog");
         let hashed = hasher.finalize();
         assert_eq!(
-            crack::<Sha512>(&["dog", "frog", "frog"].join("\n").as_bytes(), &hashed),
+            crack::<Sha512>(["dog", "frog", "frog"].join("\n").as_bytes(), &hashed),
             Some("frog".as_bytes())
         );
     }

--- a/stolon_hash/src/main.rs
+++ b/stolon_hash/src/main.rs
@@ -5,7 +5,7 @@ use stolon_hash::crack;
 fn main() -> ExitCode {
     let args: Vec<String> = env::args().collect();
 
-    if !(args.len() == 2) {
+    if args.len() != 2 {
         println!("\n\nusage: stolon_hash 'path/to/wordlist'\n\n");
         return ExitCode::FAILURE;
     }


### PR DESCRIPTION
Clippy complained about needless borrows, which was easy to fix. 

```bash
= note: -D clippy::needless-borrow implied by -D warnings
= help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow
error: this expression creates a reference which is immediately dereferenced by the compiler
```

Just removed the reference like the compiler suggested and reran clippy with no warnings:

```rust
 // crack::<Sha512>(&["dog", "frog", "bat"].join("\n").as_bytes(), &hashed)
crack::<Sha512>(["dog", "frog", "bat"].join("\n").as_bytes(), &hashed)
```